### PR TITLE
Fix bug - buf must be null terminated

### DIFF
--- a/src/bdecli.c
+++ b/src/bdecli.c
@@ -572,8 +572,10 @@ int bde_cfg_add_entry(bde_entry_t *list, char *szFQNPath, char *szName, char *sz
 				return 0;
 			}
 
-			if ('\\' == tmp[i])
+			if ('\\' == tmp[i]) {
 				strncpy_s(buf, MAX_BUFFER, tmp, i);
+				buf[i] = 0;
+			}
 			else
 				strcpy_s(buf, MAX_BUFFER, tmp);
 


### PR DESCRIPTION
buf string may contain previous data. Make sure it is null terminated. This patch is a fix for incorrect database name entries when importing a configuration file. For example, a merge file like this:
DATABASES\TEST\DB INFO\TYPE = STANDARD
DATABASES\TEST\DB INFO\PATH = C:\Data
DATABASES\TEST\DB INFO\ENABLE BCD = FALSE
DATABASES\TEST\DB INFO\DEFAULT DRIVER = PARADOX
causes an entry with name TESTBASES in the final CFG file.
